### PR TITLE
ateliers.org: ajout de la description pour l'atelier NixOS

### DIFF
--- a/ateliers.org
+++ b/ateliers.org
@@ -144,6 +144,22 @@ dans le cadre de la fabrication de CaPeL.
    :ID:       bd42ba42-4e7e-40ef-bc95-fea8d4814d15
    :END:
 
+[[https://nixos.org][NixOS]] est une distribution Linux particulière, derrière cette distribution, il existe un écosystème développé depuis 2003.
+Culminant à la thèse de Nix en 2006, le gestionnaire de paquets (de la même nature que `apt-get` ou `rpm`), central dans l'écosystème.
+
+Nix se distingue des gestionnaires de paquets usuels en l'adoption d'un langage de programmation reposant sur les paradigmes fonctionnels pour décrire les logiciels empaquetés : [[https://github.com/NixOS/nixpkgs/][nixpkgs]] le « centre logiciel » de l'écosystème Nix en est son représentant canonique.
+
+NixOS se distingue quant à lui en réutilisant intensivement ce langage afin de créer un langage de configuration « natif » au système, appelé le système de module NixOS, il est semblable à un système expert de configuration de services (e.g. serveurs web, serveurs applicatifs, et plus encore).
+
+Nous verrons :
+
+- Présentation des idées de bases de Nix: abandon du modèle FHS, chemin identifié par une empreinte cryptographique, dérivations comme généralisation du concept de paquet
+- Présentation de ce qu'on peut faire avec Nix: scripts universels auto-empaquetés, diminution de la surface d'attaque, production d'images en tout genre (Docker, machines virtuelles)
+- Présentation des idées de bases de NixOS: la dérivation « système », le système de modules NixOS, retours en arrière natifs
+- Présentation de ce qu'on peut faire avec NixOS: capturer son système sous forme d'expression, gérer des flottes de serveurs, tester sans peur, introspecter son système
+
+Intervenant : [[https://github.com/RaitoBezarius][Ryan Lahfa]]
+
 ** 2 septembre : Des outils pour mettre en valeur votre projet libre
    SCHEDULED: <2022-09-02 ven. 11:00-12:30>
    :PROPERTIES:


### PR DESCRIPTION
Voici la description pour l'atelier NixOS, je n'espère pas trop tard, pour l'envoi de la gazette.
